### PR TITLE
Add CMSIS to include paths if configured.

### DIFF
--- a/Extension/src/extension/task/opentasks.ts
+++ b/Extension/src/extension/task/opentasks.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 import * as Vscode from "vscode";
-import { isArray, isString } from "util";
+import { isArray } from "util";
 import { IarExecution } from "./iarexecution";
 
 export interface OpenTaskDefinition {

--- a/Extension/src/iar/project/config.ts
+++ b/Extension/src/iar/project/config.ts
@@ -18,6 +18,7 @@ export interface Config {
     readonly defines: Define[];
     readonly includes: IncludePath[];
     readonly preIncludes: PreIncludePath[];
+    readonly includeCmsis: boolean;
 }
 
 class XmlConfig implements Config {
@@ -26,18 +27,23 @@ class XmlConfig implements Config {
     readonly defines: Define[];
     readonly includes: IncludePath[];
     readonly preIncludes: PreIncludePath[];
+    readonly includeCmsis: boolean;
 
     constructor(xmlConfigElement: XmlNode, ewpPath: Fs.PathLike) {
         this.xml = xmlConfigElement;
 
-        if (this.xml.tagName !== 'configuration') {
-            throw new Error("Expected an xml element 'configuration' instead of '" + this.xml.tagName + "'");
+        if (this.xml.tagName !== "configuration") {
+            throw new Error(
+                "Expected an xml element 'configuration' instead of '" +
+                    this.xml.tagName +
+                    "'"
+            );
         }
 
         const projectRoot = Path.parse(ewpPath.toString()).dir;
 
         this.defines = Define.fromXml(xmlConfigElement);
-        this.includes = IncludePath.fromXmlData(xmlConfigElement, projectRoot);
+        [this.includes, this.includeCmsis] = IncludePath.fromXmlData(xmlConfigElement, projectRoot);
         this.preIncludes = PreIncludePath.fromXml(xmlConfigElement, projectRoot);
     }
 

--- a/Extension/src/iar/project/define.ts
+++ b/Extension/src/iar/project/define.ts
@@ -100,6 +100,19 @@ export namespace Define {
         return [];
     }
 
+    export function fromSettings(settingsDefine: string): Define {
+        let components = settingsDefine.split("=", 2);
+
+        if (components.length != 2) {
+            throw new Error("Invalid define format!")
+        }
+
+        return {
+            identifier: components[0],
+            value: components[1].length == 0 ? undefined : components[1],
+        };
+    }
+
     export function fromSourceFile(path: Fs.PathLike): Define[] {
         let buf = Fs.readFileSync(path.toString());
 

--- a/Extension/src/iar/project/includepath.ts
+++ b/Extension/src/iar/project/includepath.ts
@@ -88,7 +88,7 @@ export class StringIncludePath implements IncludePath {
 }
 
 export namespace IncludePath {
-    export function fromXmlData(xml: XmlNode, projectPath: Fs.PathLike): IncludePath[] {
+    export function fromXmlData(xml: XmlNode, projectPath: Fs.PathLike): [IncludePath[], boolean] {
         let settings = IarXml.findSettingsFromConfig(xml, '/ICC.*/');
 
         if (settings) {
@@ -106,11 +106,22 @@ export namespace IncludePath {
                     }
                 });
 
-                return includePaths;
+                let cmsisIncluded = false;
+                let iccCmsis = IarXml.findOptionFromSettings(settings, '/IccCmsis/');
+
+                if (iccCmsis) {
+                    let state = iccCmsis.getFirstChildByName('state');
+
+                    if (state !== undefined && state.text === "1") {
+                        cmsisIncluded = true;
+                    }
+                }
+
+                return [includePaths, cmsisIncluded];
             }
         }
 
-        return [];
+        return [[], false];
     }
 
     export function fromCompilerOutput(output: string): IncludePath[] {

--- a/Extension/src/iar/tools/compiler.ts
+++ b/Extension/src/iar/tools/compiler.ts
@@ -11,13 +11,14 @@ import * as Process from "child_process";
 import { FsUtils } from "../../utils/fs";
 import { ListUtils } from "../../utils/utils";
 import { Define } from "../project/define";
-import { IncludePath } from "../project/includepath";
+import { IncludePath, StringIncludePath } from "../project/includepath";
 
 export interface Compiler {
     readonly name: string;
     readonly path: Fs.PathLike;
     readonly defines: Define[];
     readonly includePaths: IncludePath[];
+    readonly cmsisIncludePath: IncludePath;
 }
 
 type CompilerOutput = { defines: Define[], includePaths: IncludePath[] };
@@ -26,10 +27,11 @@ class IarCompiler implements Compiler {
     readonly path: Fs.PathLike;
     readonly defines: Define[];
     readonly includePaths: IncludePath[];
+    readonly cmsisIncludePath: IncludePath;
 
     /**
      * Create a new Compiler object.
-     * 
+     *
      * @param path Path to a compiler
      */
     constructor(path: Fs.PathLike) {
@@ -43,6 +45,7 @@ class IarCompiler implements Compiler {
 
         this.defines = defines;
         this.includePaths = includePaths;
+        this.cmsisIncludePath = new StringIncludePath(Path.join(Fs.realpathSync(path), "..\\..\\CMSIS\\Core\\Include"));
     }
 
     get name(): string {
@@ -116,7 +119,7 @@ class IarCompiler implements Compiler {
 export namespace Compiler {
     /**
      * Collect all available compilers for a platform.
-     * 
+     *
      * @param platform The platform for which we must find compilers.
      */
     export function collectCompilersFrom(root: Fs.PathLike): Compiler[] {
@@ -145,7 +148,7 @@ export namespace Compiler {
 
     /**
      * Create a new Compiler object.
-     * 
+     *
      * @param path The path to the compiler
      * @returns {undefined} When the path does not point to a valid compiler
      * @returns {Compiler} When the path points to a valid compiler

--- a/Extension/src/vsc/CppToolsConfigGenerator.ts
+++ b/Extension/src/vsc/CppToolsConfigGenerator.ts
@@ -63,7 +63,7 @@ export namespace CppToolsConfigGenerator {
         return array;
     }
 
-    function toIncludePathArray(includes: IncludePath[], absolutePath: boolean = false): string[] {
+    function toIncludePathArray(includes: IncludePath[], absolutePath: boolean): string[] {
         let array: string[] = [];
 
         includes.forEach(item => {
@@ -139,25 +139,31 @@ export namespace CppToolsConfigGenerator {
         let obj: any = {};
 
         let defines: string[] = [];
-        let includepaths: string[] = [];
+        let includepaths: IncludePath[] = [];
         let preincludes: string[] = [];
 
         if (config) {
             defines = defines.concat(toDefineArray(config.defines));
-            includepaths = includepaths.concat(toIncludePathArray(config.includes));
+            includepaths = includepaths.concat(config.includes);
             preincludes = preincludes.concat(toPreIncludePathArray(config.preIncludes));
         }
 
         defines = defines.concat(Settings.getDefines());
 
+        let includepathStrings = toIncludePathArray(includepaths, false);
+
         if (compiler) {
             defines = defines.concat(toDefineArray(compiler.defines));
-            includepaths = includepaths.concat(toIncludePathArray(compiler.includePaths, true));
+            includepathStrings = includepathStrings.concat(toIncludePathArray(compiler.includePaths, true));
+
+            if (config && config.includeCmsis) {
+                includepathStrings.push(compiler.cmsisIncludePath.absolutePath.toString());
+            }
         }
 
         obj["name"] = "IAR";
         obj["defines"] = defines;
-        obj["includePath"] = includepaths;
+        obj["includePath"] = includepathStrings;
         obj["forcedInclude"] = preincludes;
 
         obj["cStandard"] = Settings.getCStandard();


### PR DESCRIPTION
Currently, the CMSIS include path is not added to the `c_cpp_properties.json` file which results in unresolved includes for projects that use the IAR-provided CMSIS library.

This PR resolves this by picking out the relevant project property and adding the associated include. A unit test was added to cover this case.

I'm very open to feedback on this -- I personally am not a fan of the hard-coded compiler-relative path to CMSIS but I haven't thought of anything cleverer so far.