### PR TITLE
IAR extended keyword support

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -97,6 +97,16 @@
         }
       ]
     },
+    "grammars": [
+      {
+        "scopeName": "iar-keywords.injection",
+        "path": "./syntaxes/iar-c-cpp.tmLanguage.json",
+        "injectTo": [
+          "source.c",
+          "source.cpp"
+        ]
+      }
+    ],
     "configuration": {
       "title": "IAR",
       "properties": {

--- a/Extension/src/iar/project/define.ts
+++ b/Extension/src/iar/project/define.ts
@@ -76,6 +76,10 @@ class StringDefine implements Define {
 }
 
 export namespace Define {
+    export function fromIdentifierValuePair(identifier: string, value: string): Define {
+        return new StringDefine(identifier, value);
+    }
+
     export function fromXml(configNode: XmlNode): Define[] {
         let settings = IarXml.findSettingsFromConfig(configNode, '/ICC.*/');
 

--- a/Extension/src/iar/project/keyword.ts
+++ b/Extension/src/iar/project/keyword.ts
@@ -20,11 +20,18 @@ class StringKeyword implements Keyword {
 }
 
 export namespace Keyword {
+    /**
+     * Reads keywords from a platform syntax file (usually called syntax_icc.cfg)
+     * @param path The path to the syntax file
+     */
     export function fromSyntaxFile(path: Fs.PathLike): Keyword[] {
         const buf = Fs.readFileSync(path.toString());
-        const content = buf.toString();
+        const contents = buf.toString();
+        return fromSyntaxFileContents(contents)
+    }
 
-        let lines = content.split(/\n|\r\n/);
+    export function fromSyntaxFileContents(contents: string): Keyword[] {
+        let lines = contents.split(/\n|\r\n/);
         lines = lines.filter(line => line && line.trim()); // remove empty lines
         lines = lines.map(line => line.trim()) // some older workbenches have keywords with surrounding spaces
         return lines.map(line => new StringKeyword(line));

--- a/Extension/src/iar/project/keyword.ts
+++ b/Extension/src/iar/project/keyword.ts
@@ -26,12 +26,14 @@ export namespace Keyword {
 
         let lines = content.split(/\n|\r\n/);
         lines = lines.filter(line => line && line.trim()); // remove empty lines
+        lines = lines.map(line => line.trim()) // some older workbenches have keywords with surrounding spaces
         return lines.map(line => new StringKeyword(line));
     }
 
     // Right now the best way to get cpptools to recognize custom keywords is to
     // pretend they're compiler-defined macros, so we need a way to convert keywords to macros
     export function toDefine(keyword: Keyword) {
-        return Define.fromIdentifierValuePair(keyword.identifier, " ");
+        // We make the define expand to an empty string to force the error checker to ignore it
+        return Define.fromIdentifierValuePair(keyword.identifier, "");
     }
 }

--- a/Extension/src/iar/project/keyword.ts
+++ b/Extension/src/iar/project/keyword.ts
@@ -1,0 +1,37 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+'use strict';
+
+import * as Fs from "fs";
+import { Define } from "./define";
+
+export interface Keyword {
+    readonly identifier: string;
+}
+
+class StringKeyword implements Keyword {
+    readonly identifier: string;
+
+    constructor(identifier: string) {
+        this.identifier = identifier;
+    }
+}
+
+export namespace Keyword {
+    export function fromSyntaxFile(path: Fs.PathLike): Keyword[] {
+        const buf = Fs.readFileSync(path.toString());
+        const content = buf.toString();
+
+        let lines = content.split(/\n|\r\n/);
+        lines = lines.filter(line => line && line.trim()); // remove empty lines
+        return lines.map(line => new StringKeyword(line));
+    }
+
+    // Right now the best way to get cpptools to recognize custom keywords is to
+    // pretend they're compiler-defined macros, so we need a way to convert keywords to macros
+    export function toDefine(keyword: Keyword) {
+        return Define.fromIdentifierValuePair(keyword.identifier, " ");
+    }
+}

--- a/Extension/src/iar/tools/compiler.ts
+++ b/Extension/src/iar/tools/compiler.ts
@@ -12,12 +12,14 @@ import { FsUtils } from "../../utils/fs";
 import { ListUtils, OsUtils } from "../../utils/utils";
 import { Define } from "../project/define";
 import { IncludePath } from "../project/includepath";
+import { Keyword } from "../project/keyword";
 
 export interface Compiler {
     readonly name: string;
     readonly path: Fs.PathLike;
     readonly defines: Define[];
     readonly includePaths: IncludePath[];
+    readonly supportedKeywords: Keyword[];
 
     prepare(): void;
 }
@@ -28,6 +30,7 @@ class IarCompiler implements Compiler {
     readonly path: Fs.PathLike;
     private _defines: Define[] | undefined;
     private _includePaths: IncludePath[] | undefined;
+    private _supportedKeywords: Keyword[] | undefined;
 
     /**
      * Create a new Compiler object.
@@ -43,6 +46,7 @@ class IarCompiler implements Compiler {
 
         this._defines = undefined;
         this._includePaths = undefined;
+        this._supportedKeywords = undefined;
     }
 
     public prepare(): void {
@@ -51,6 +55,9 @@ class IarCompiler implements Compiler {
 
             this._defines = defines;
             this._includePaths = includePaths;
+        }
+        if (this._supportedKeywords === undefined) {
+            this._supportedKeywords = this.computeSupportedKeywords();
         }
     }
 
@@ -71,6 +78,14 @@ class IarCompiler implements Compiler {
             return [];
         } else {
             return this._includePaths;
+        }
+    }
+
+    get supportedKeywords(): Keyword[] {
+        if (this._supportedKeywords === undefined) {
+            return [];
+        } else {
+            return this._supportedKeywords;
         }
     }
 
@@ -136,6 +151,18 @@ class IarCompiler implements Compiler {
     private parseIncludePathsFrom(compilerOutput: string): IncludePath[] {
         return IncludePath.fromCompilerOutput(compilerOutput);
     }
+
+    private computeSupportedKeywords(): Keyword[] {
+        // C syntax files are named <platform dir>/config/syntax_icc.cfg
+        const platformBasePath = Path.dirname(this.path.toString()) + "/.."
+        const filePath         = platformBasePath + "/config/syntax_icc.cfg"
+        if (Fs.existsSync(filePath)) {
+            return Keyword.fromSyntaxFile(filePath);
+        } else {
+            return [];
+        }
+    }
+
 }
 
 export namespace Compiler {

--- a/Extension/src/vsc/CppToolsConfigGenerator.ts
+++ b/Extension/src/vsc/CppToolsConfigGenerator.ts
@@ -16,6 +16,7 @@ import { Define } from "../iar/project/define";
 import { Compiler } from "../iar/tools/compiler";
 import { FsUtils } from "../utils/fs";
 import { Settings } from "../extension/settings";
+import { Keyword } from "../iar/project/keyword";
 
 export namespace CppToolsConfigGenerator {
     type loadConfigReturn = {
@@ -156,6 +157,10 @@ export namespace CppToolsConfigGenerator {
 
         if (compiler) {
             defines = defines.concat(toDefineArray(compiler.defines));
+            // To force cpptools to recognize extended keywords we pretend they're compiler-defined macros
+            const keywordDefines = compiler.supportedKeywords.map(Keyword.toDefine);
+            defines = defines.concat(toDefineArray(keywordDefines));
+
             includepaths = includepaths.concat(toIncludePathArray(compiler.includePaths, true));
         }
 

--- a/Extension/src/vsc/CppToolsConfigGenerator.ts
+++ b/Extension/src/vsc/CppToolsConfigGenerator.ts
@@ -58,7 +58,7 @@ export namespace CppToolsConfigGenerator {
         let array: string[] = [];
 
         defines.forEach(item => {
-            if (item.value) {
+            if (item.value != null) {
                 array.push(item.identifier + "=" + item.value);
             } else {
                 array.push(item.identifier);

--- a/Extension/syntaxes/iar-c-cpp.tmLanguage.json
+++ b/Extension/syntaxes/iar-c-cpp.tmLanguage.json
@@ -1,0 +1,654 @@
+{
+    "scopeName": "iar-keywords.injection",
+    "injectionSelector": "L:source.c, L:source.cpp",
+    "patterns": [
+        {
+            "name": "keyword.c",
+            "match": "(__aapcs_core)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__absolute)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__absolute_to_pic)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__acall)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__arm)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__asm)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__banked_func)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__banked_func_ext2)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__bdata)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__big_endian)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__bit)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__bitvar)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__bkpt)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__brel)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__brel23)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__C_task)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__callt)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__cc_version1)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__cc_version2)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__cmse_nonsecure_call)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__cmse_nonsecure_entry)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__code)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__code20)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__code21)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__code24)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__code32)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__count_ones_left)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__count_ones_right)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__count_zeros_left)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__count_zeros_right)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__data)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__data13)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__data16)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__data17)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__data20)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__data21)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__data24)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__data32)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__data_overlay)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__dbgreg)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__debug_exception)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__eeprom)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__exception)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__ext_io)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__ext_stack_reentrant)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__far22)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__far22_code)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__far22_rom)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__far)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__far_code)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__far_func)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__far_rom)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__far_22)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__far_22_code)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__far_22_rom)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__farflash)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__farfunc)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__fast_interrupt)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__fiq)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__flash)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__flashvault)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__flashvault_impl)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__flat)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__fpu_sqrt_float32)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__fpu_sqrt_float64)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__generic)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__get_processor_register)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__huge)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__huge_code)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__huge_func)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__huge_rom)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__hugeflash)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__idata)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__idata_overlay)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__idata_reentrant)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__imported)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__interrupt)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__interwork)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__intrinsic)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__io)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__irq)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__ixdata)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__little_endian)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__monitor)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__near)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__near_func)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__near_rom)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__nearfunc)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__nested)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__no_alloc)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__no_alloc16)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__no_alloc_str)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__no_alloc_str16)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__no_bit_access)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__no_init)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__no_pic)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__no_runtime_init)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__no_save)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__no_xdata)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__noreturn)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__nounwind)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__overlay_near_func)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__packed)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__pcrel)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__pdata)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__pdata_reentrant)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__persistent)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__pic_to_absolute)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__ramfunc)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__raw)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__regbank_interrupt)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__regvar)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__ret_addr_on_ext_stack)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__root)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__ro_placement)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__saddr)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__saturated_add)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__saturated_sub)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__save_reg20)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__sbdata16)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__sbdata24)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__sbrel)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__scall)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__set_processor_register)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__sfr)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__simple)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__softfp)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__spec_string)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__stackless)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__svc)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__swi)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__synchronize_exceptions)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__synchronize_memory)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__synchronize_pipeline)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__syscall)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__sysreg)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__task)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__thumb)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__tiny)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__tiny_func)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__tinyflash)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__ubdef)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__upper_mul64)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__using)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__v1_call)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__v2_call)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__value_in_regs)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__veccopy)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__vecset)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__version_1)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__version_2)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__version_3)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__version_4)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__vfp)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__weak)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__x)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__x_z)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__xdata)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__xdata_reentrant)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__xdata_rom)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__z)\\s"
+        },
+        {
+            "name": "keyword.c",
+            "match": "(__z_x)\\s"
+        }
+    ]
+}

--- a/Extension/test/unitTests/cpptoolsconfiggenerator.test.ts
+++ b/Extension/test/unitTests/cpptoolsconfiggenerator.test.ts
@@ -12,6 +12,7 @@ import { Define } from "../../src/iar/project/define";
 import { IncludePath } from "../../src/iar/project/includepath";
 import { PreIncludePath } from "../../src/iar/project/preincludepath";
 import { Compiler } from "../../src/iar/tools/compiler";
+import { Keyword } from "../../src/iar/project/keyword";
 
 suite("CppToolsConfigGenerator", () => {
     test("Verify fixed path", () => {
@@ -46,7 +47,9 @@ suite("CppToolsConfigGenerator", () => {
 
         Assert.notEqual(iarConfiguration, undefined);
 
-        let defines = config.defines.concat(compiler.defines);
+        let defines = config.defines
+                                .concat(compiler.defines)
+                                .concat(compiler.supportedKeywords.map(Keyword.toDefine))
         let includePaths = config.includes.concat(compiler.includePaths);
         let preincludes = config.preIncludes;
 
@@ -101,12 +104,16 @@ suite("CppToolsConfigGenerator", () => {
         let includePaths: IncludePath[] = [
             { path: "C:\\MyCompiler\\inc", absolutePath: "C:\\MyCompiler\\inc", workspacePath: "..\\MyCompiler\\inc" },
         ];
+        let keywords: Keyword[] = [
+            { identifier: "MyKeyword" }
+        ];
 
         return {
             name: "cc",
             path: path,
             defines: defines,
             includePaths: includePaths,
+            supportedKeywords: keywords,
             prepare: function () { }
         };
     }

--- a/Extension/test/unitTests/keyword.test.ts
+++ b/Extension/test/unitTests/keyword.test.ts
@@ -1,0 +1,51 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+import * as Assert from "assert";
+import { Keyword } from "../../src/iar/project/keyword";
+
+suite("Test keyword parsers", () => {
+    suite("Test .cfg file parser", () => {
+        test("Empty contents", () => {
+            const src = "";
+
+            const keywords = Keyword.fromSyntaxFileContents(src);
+
+            Assert.equal(keywords.length, 0);
+        });
+
+        test("Several keywords", () => {
+            const src = "word1\n__word2\n_w_o_r_d_3";
+
+            const keywords = Keyword.fromSyntaxFileContents(src);
+
+            Assert.equal(keywords.length, 3);
+            Assert.equal(keywords[0].identifier, "word1");
+            Assert.equal(keywords[1].identifier, "__word2");
+            Assert.equal(keywords[2].identifier, "_w_o_r_d_3");
+        });
+
+        test("Untrimmed keywords", () => {
+            const src = "   word1\n __word2 \n_w_o_r_d_3   ";
+
+            const keywords = Keyword.fromSyntaxFileContents(src);
+
+            Assert.equal(keywords.length, 3);
+            Assert.equal(keywords[0].identifier, "word1");
+            Assert.equal(keywords[1].identifier, "__word2");
+            Assert.equal(keywords[2].identifier, "_w_o_r_d_3");
+        });
+
+        test("Empty lines", () => {
+            const src = "\n\nword1\n__word2\n   \n_w_o_r_d_3\n\n\n";
+
+            const keywords = Keyword.fromSyntaxFileContents(src);
+
+            Assert.equal(keywords.length, 3);
+            Assert.equal(keywords[0].identifier, "word1");
+            Assert.equal(keywords[1].identifier, "__word2");
+            Assert.equal(keywords[2].identifier, "_w_o_r_d_3");
+        });
+    });
+});


### PR DESCRIPTION
Includes both syntax highlighting and adding the keywords as macros to trick the cpptools intellisense.

Finding the keywords is done here:
https://github.com/pluyckx/iar-vsc/blob/320881da368bd5771015dfa321ceb48d392956a6/Extension/src/iar/tools/compiler.ts#L155-L164

Maybe there should be a backup list of all possible keywords that we can use if `syntax_icc.cfg` isn't available?