### PR TITLE
Scan for new workbenches if iarInstallDirectories changes

### DIFF
--- a/Extension/src/extension/settings.ts
+++ b/Extension/src/extension/settings.ts
@@ -11,7 +11,7 @@ import { Handler } from "../utils/handler";
 
 class SettingsFile {
     private path_: Fs.PathLike;
-    private json_: any
+    private json_: any;
 
     constructor(path: Fs.PathLike) {
         this.path_ = path;
@@ -78,11 +78,11 @@ export namespace Settings {
         Defines = "defines",
         CStandard = "cStandard",
         CppStandard = "cppStandard",
-        ExtraBuildArguments = "extraBuildArguments"
+        ExtraBuildArguments = "extraBuildArguments",
+        IarInstallDirectories = "iarInstallDirectories",
     }
 
     const section = "iarvsc";
-    const iarInstallDirectories = "iarInstallDirectories";
 
     let settingsFile: SettingsFile | undefined = undefined;
     let observers: Map<Field, Handler<ChangeHandler>[]> = new Map();
@@ -108,7 +108,7 @@ export namespace Settings {
     }
 
     export function getIarInstallDirectories(): Fs.PathLike[] {
-        let directories = Vscode.workspace.getConfiguration(section).get(iarInstallDirectories);
+        let directories = Vscode.workspace.getConfiguration(section).get(Field.IarInstallDirectories);
 
         if (directories) {
             return directories as string[];

--- a/Extension/src/iar/tools/manager.ts
+++ b/Extension/src/iar/tools/manager.ts
@@ -43,9 +43,11 @@ class IarToolManager implements ToolManager {
     }
 
     add(...workbenches: Workbench[]): void {
-        this.workbenches_ = Workbench.mergeUnique(this.workbenches_, workbenches);
+        if (workbenches.length > 0) {
+            this.workbenches_ = Workbench.mergeUnique(this.workbenches_, workbenches);
 
-        this.fireInvalidateEvent();
+            this.fireInvalidateEvent();
+        }
     }
 
     collectFrom(directory: Fs.PathLike): void {

--- a/Extension/src/main.ts
+++ b/Extension/src/main.ts
@@ -24,14 +24,8 @@ export function activate(context: vscode.ExtensionContext) {
     SettingsMonitor.monitorConfiguration(UI.getInstance().config.model);
     UI.getInstance().show();
 
-    let roots = Settings.getIarInstallDirectories();
-
-    roots.forEach(path => {
-        IarVsc.toolManager.collectFrom(path);
-    });
-    if (IarVsc.toolManager.workbenches.length === 0) {
-        vscode.window.showErrorMessage("IAR: Unable to find any IAR workbenches to use, you will need to configure this to use the extension (see [the documentation](https://iar-vsc.readthedocs.io/en/latest/pages/user_guide.html#extension-settings))");
-    }
+    loadTools();
+    Settings.observeSetting(Settings.Field.IarInstallDirectories, loadTools);
 
     IarTaskProvider.register();
     CStatTaskProvider.register(context);
@@ -40,6 +34,19 @@ export function activate(context: vscode.ExtensionContext) {
 export function deactivate() {
     IarTaskProvider.unregister();
     CStatTaskProvider.unRegister();
+}
+
+function loadTools() {
+    let roots = Settings.getIarInstallDirectories();
+
+    roots.forEach(path => {
+        IarVsc.toolManager.collectFrom(path);
+    });
+
+    if (IarVsc.toolManager.workbenches.length === 0) {
+        vscode.window.showErrorMessage("IAR: Unable to find any IAR workbenches to use, you will need to configure this to use the extension (see [the documentation](https://iar-vsc.readthedocs.io/en/latest/pages/user_guide.html#extension-settings))");
+    }
+
 }
 
 namespace IarVsc {


### PR DESCRIPTION
If the user changes `iarInstallDirectories`, scan for new workbenches immediately, rather than making the user reload the window for changes to take effect.