### PR TITLE
Settings clarifications/rename + release notes

### DIFF
--- a/Extension/README.md
+++ b/Extension/README.md
@@ -133,6 +133,13 @@ This will also let the extension find any other workbench installations in that 
 
 ## Release Notes
 
+### 1.2.1
+
+* Remove 'Scan for task output' dialog when running C-STAT tasks
+* Rescan for workspaces when changing `iarInstallDirectories`
+* Change name of C-STAT settings
+* Update readme section on settings
+
 ### 1.2.0
 
 * Change extension name and icon

--- a/Extension/README.md
+++ b/Extension/README.md
@@ -1,6 +1,6 @@
 # iar-vsc README
 
-This plugin makes it possible to combine the IAR Systems compiler solutions with Visual Studio Code. The goal is to support all IAR Systems compiler variants like for example Arm, RISC-V, MSP430, AVR, STM8, 8051, Renesas RX, RL78 and RH850. If you find any problems with this plugin, please open an issue on GitHub and include the compiler and version used. If possible, include also the project file (.ewp). This plugin works on any operating system supported by VS Code and IAR Systems.
+This plugin makes it possible to combine the IAR Systems compiler solutions with Visual Studio Code. The goal is to support all IAR Systems compiler variants like for example Arm, RISC-V, MSP430, AVR, STM8, 8051, Renesas RX, RL78 and RH850. If you find any problems with this plugin, please open an issue on GitHub and include the compiler and version used. If possible, include also the project file (.ewp). This plugin works on any operating system supported by VS Code and IAR Systems. IAR Systems has contributed to the development of this plugin.
 
 The plugin can parse *ewp* files and convert them to a valid `c_cpp_properties.json` configuration which is used by the *cpptools* extension made by *Microsoft*.
 In the `Features` section you can find more information on how to use this extension.
@@ -113,15 +113,17 @@ This extensions presumes that you have installed `cpptools` of `microsoft`.
 
 ## Extension Settings
 
+To change extension settings, go to `Ctrl+Shift+P->Preferences: Open Settings (JSON)` to open your `settings.json` file and add the appropriate json entries.
 This extension contributes the following settings:
 
 * `iarvsc.iarInstallDirectories`: The rootfolder where all IAR workbenches are installed. By default this is `C:\Program Files (x86)\Iar Systems`. The default settings contain also the non-x86 folder in case IAR will move to 64-bit installations.
-Example for a custom install location:
+For example, if your Embedded Workbench installation is at `D:\Iar Systems\Embedded Workbench 8.40`,
+add the following to your `settings.json` file:
 
 ```json
-"iarvsc.iarInstallDirectories": ["C:\\Custom\\Install\\Path"],
+"iarvsc.iarInstallDirectories": ["D:\\Iar Systems"],
 ```
-Note that you may need to reload VSCode after changing this.
+This will also let the extension find any other workbench installations in that folder (e.g. `D:\Iar Systems\My Second Workbench 7.20`).
 
 * `iarvsc.defines`: Some custom defines you can add to the define list. They follow the `identifier=value` structure. This list will contain all intrinsic compiler functions that are known by the author of this extension. If some are missing, create a GitHub issue.
 * `iarvsc.cstatFilterLevel`: Sets the lowest severity of C-STAT warnings to display.

--- a/Extension/README.md
+++ b/Extension/README.md
@@ -126,8 +126,8 @@ add the following to your `settings.json` file:
 This will also let the extension find any other workbench installations in that folder (e.g. `D:\Iar Systems\My Second Workbench 7.20`).
 
 * `iarvsc.defines`: Some custom defines you can add to the define list. They follow the `identifier=value` structure. This list will contain all intrinsic compiler functions that are known by the author of this extension. If some are missing, create a GitHub issue.
-* `iarvsc.cstatFilterLevel`: Sets the lowest severity of C-STAT warnings to display.
-* `iarvsc.cstatDisplayLowSeverityWarningsAsHints`: When the filter level is set to low, this option will display low severity warnings as 'hints' instead of warnings. This is helpful if you have lots of low severity warnings and want to hide them from the problems list (but still see them in the editor).
+* `iarvsc.c-StatFilterLevel`: Sets the lowest severity of C-STAT warnings to display.
+* `iarvsc.c-StatDisplayLowSeverityWarningsAsHints`: When the filter level is set to low, this option will display low severity warnings as 'hints' instead of warnings. This is helpful if you have lots of low severity warnings and want to hide them from the problems list (but still see them in the editor).
 
 ## Known Issues
 

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -164,7 +164,7 @@
           "description": "The c++ standard to use in the config tool configuration.",
           "default": "${default}"
         },
-        "iarvsc.cstatFilterLevel": {
+        "iarvsc.c-StatFilterLevel": {
           "description": "C-STAT warnings with a lower severity than this are filtered out.",
           "default": "Medium",
           "type": "string",
@@ -174,7 +174,7 @@
             "High"
           ]
         },
-        "iarvsc.cstatDisplayLowSeverityWarningsAsHints": {
+        "iarvsc.c-StatDisplayLowSeverityWarningsAsHints": {
           "description": "If the filter level is set to Low, displays low severity C-STAT warnings as hints rather than warnings. This hides them from the problem list, but still shows them in the editor.",
           "type": "boolean",
           "default": false

--- a/Extension/package.json
+++ b/Extension/package.json
@@ -2,7 +2,7 @@
   "name": "iar-vsc",
   "displayName": "IAR For Visual Studio Code",
   "description": "Develop IAR projects with intellisense, C-STAT and build support.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "publisher": "pluyckx",
   "icon": "images/logo.png",
   "preview": true,

--- a/Extension/src/extension/task/cstat/cstattaskexecution.ts
+++ b/Extension/src/extension/task/cstat/cstattaskexecution.ts
@@ -70,7 +70,7 @@ export class CStatTaskExecution implements Vscode.Pseudoterminal {
                 this.writeEmitter.fire("Analyzing output...\r\n");
                 this.diagnostics.clear();
 
-                const filterString = Vscode.workspace.getConfiguration("iarvsc").get<string>("cstatFilterLevel");
+                const filterString = Vscode.workspace.getConfiguration("iarvsc").get<string>("c-StatFilterLevel");
                 const filterLevel = filterString ? 
                                         CStat.SeverityStringToSeverityEnum(filterString)
                                         : CStat.CStatWarningSeverity.LOW;
@@ -115,7 +115,7 @@ export class CStatTaskExecution implements Vscode.Pseudoterminal {
         const range = new Vscode.Range(pos, pos);
 
         let severity = Vscode.DiagnosticSeverity.Warning;
-        if (Vscode.workspace.getConfiguration("iarvsc").get<boolean>("cstatDisplayLowSeverityWarningsAsHints")) {
+        if (Vscode.workspace.getConfiguration("iarvsc").get<boolean>("c-StatDisplayLowSeverityWarningsAsHints")) {
             if (warning.severity === CStat.CStatWarningSeverity.LOW) { severity = Vscode.DiagnosticSeverity.Hint; }
         }
 

--- a/docs/pages/release_notes.rst
+++ b/docs/pages/release_notes.rst
@@ -5,6 +5,14 @@
 Release Notes
 =============
 
+1.2.1
+-----
+
+* Remove 'Scan for task output' dialog when running C-STAT tasks
+* Automatically rescan for workspaces when changing ``iarInstallDirectories``
+* Change name of C-STAT settings
+* Update readme section on settings
+
 1.2.0
 -----
 * Change extension name and icon

--- a/docs/pages/user_guide.rst
+++ b/docs/pages/user_guide.rst
@@ -165,8 +165,8 @@ This extension contributes the following settings:
 This will also let the extension find any other workbench installations in that folder (e.g. ``D:\Iar Systems\My Second Workbench 7.20``).
 
 * ``iarvsc.defines``: Some custom defines you can add to the define list. They follow the ``identifier=value`` structure. This list will contain all intrinsic compiler functions that are known by the author of this extension. If some are missing, create a GitHub issue.
-* ``iarvsc.cstatFilterLevel``: Sets the lowest severity of C-STAT warnings to display.
-* ``iarvsc.cstatDisplayLowSeverityWarningsAsHints``: When the filter level is set to low, this option will display low severity warnings as 'hints' instead of warnings. This is helpful if you have lots of low severity warnings and want to hide them from the problems list (but still see them in the editor).
+* ``iarvsc.c-StatFilterLevel``: Sets the lowest severity of C-STAT warnings to display.
+* ``iarvsc.c-StatDisplayLowSeverityWarningsAsHints``: When the filter level is set to low, this option will display low severity warnings as 'hints' instead of warnings. This is helpful if you have lots of low severity warnings and want to hide them from the problems list (but still see them in the editor).
 
 Advanced usage
 ______________

--- a/docs/pages/user_guide.rst
+++ b/docs/pages/user_guide.rst
@@ -153,14 +153,16 @@ Some information about the used config parameters:
 Extension Settings
 ------------------
 
+To change extension settings, go to ``Ctrl+Shift+P->Preferences: Open Settings (JSON)`` to open your ``settings.json`` file and add the appropriate json entries.
 This extension contributes the following settings:
 
-* ``iarvsc.iarInstallDirectories``: The rootfolder where all IAR workbenches are installed. By default this is ``C:\Program Files (x86)\Iar Systems``. The default settings contain also the non-x86 folder in case IAR will move to 64-bit installations. Example for a custom install location:
+* ``iarvsc.iarInstallDirectories``: The rootfolder where all IAR workbenches are installed. By default this is ``C:\Program Files (x86)\Iar Systems``. The default settings contain also the non-x86 folder in case IAR will move to 64-bit installations. For example, if your Embedded Workbench installation is at ``D:\Iar Systems\Embedded Workbench 8.40``, add the following to your ``settings.json`` file:
 
 .. code-block:: json
 
-    "iarvsc.iarInstallDirectories": ["C:\\Custom\\Install\\Path"],
-Note that you may need to reload VSCode after changing this.
+    "iarvsc.iarInstallDirectories": ["D:\\Iar Systems"],
+
+This will also let the extension find any other workbench installations in that folder (e.g. ``D:\Iar Systems\My Second Workbench 7.20``).
 
 * ``iarvsc.defines``: Some custom defines you can add to the define list. They follow the ``identifier=value`` structure. This list will contain all intrinsic compiler functions that are known by the author of this extension. If some are missing, create a GitHub issue.
 * ``iarvsc.cstatFilterLevel``: Sets the lowest severity of C-STAT warnings to display.


### PR DESCRIPTION
* Makes it a little more clear how to set `iarInstallDirectories`
* Renames the cstat settings to make the formatted string in the settings view look better
* Adds release notes for this, #75 and #76.