### PR TITLE
Remove old C-STAT commands. Other fixes.

### DIFF
--- a/Extension/package.json
+++ b/Extension/package.json
@@ -30,8 +30,6 @@
     "onCommand:iar.selectConfiguration",
     "onCommand:iar.generateCppToolsConfig",
     "onCommand:iar.selectIarWorkspace",
-    "oncommand:iar.runCStat",
-    "oncommand:iar.clearCStat",
     "workspaceContains:**/*.ewp"
   ],
   "main": "./out/src/main",
@@ -81,16 +79,6 @@
         "command": "iar-settings.project-configuration",
         "title": "Get the selected project configuration",
         "category": "IAR Settings"
-      },
-      {
-        "command": "iar.runCStat",
-        "title": "Run C-STAT Analysis",
-        "category": "IAR"
-      },
-      {
-        "command": "iar.clearCStat",
-        "title": "Clear C-STAT Diagnostics",
-        "category": "IAR"
       }
     ],
     "views": {

--- a/Extension/src/iar/tools/cstat.ts
+++ b/Extension/src/iar/tools/cstat.ts
@@ -59,7 +59,7 @@ export namespace CStat {
             sqlProc.stdin.write("SELECT sql FROM sqlite_master WHERE type IS 'table' AND name IS 'warnings';\n");
             sqlProc.stdout.once('data', tableData => {
                 // The name of the check is contained in property_alias if present, otherwise in property_id
-                const checkIdColumn = tableData.includes("property_alias") ? "property_alias" : "property_id";
+                const checkIdColumn = tableData.toString().includes("property_alias") ? "property_alias" : "property_id";
 
                 sqlProc.stdin.write("SELECT Count(*) FROM warnings;\n");
                 sqlProc.stdout.once('data', data => {

--- a/Extension/src/iar/tools/cstat.ts
+++ b/Extension/src/iar/tools/cstat.ts
@@ -37,7 +37,6 @@ export namespace CStat {
         COLUMN = "column_num",
         MSG = "msg",
         SEVERITY = "severity",
-        CHECKID = "property_alias",
         // TRACE = "encoded_trace",
     }
     const fieldsToLoad: string[] = Object.values(CStatWarningField);
@@ -52,35 +51,41 @@ export namespace CStat {
         if (sqliteBin === null) { return Promise.reject("Couldn't find sqlite binaries for cstat. Your OS likely isn't supported."); }
         const sqliteBinPath = join(extensionPath.toString(), "sqlite-bin", sqliteBin);
         const cstatDBPath = getCStatDBPath(projectPath, configurationName);
-        if (!Fs.existsSync(cstatDBPath)) { Promise.reject("Couldn't find cstat DB: " + cstatDBPath); }
+        if (!Fs.existsSync(cstatDBPath)) { return Promise.reject("Couldn't find cstat DB: " + cstatDBPath); }
 
         return new Promise((resolve, reject) => {
             const sqlProc = spawn(sqliteBinPath, [cstatDBPath, "-csv"]); // we want csv output for easier parsing
 
-            sqlProc.stdin.write("SELECT Count(*) FROM warnings;\n");
-            sqlProc.stdout.once('data', data => {
-                const expectedRows = Number(data.toString());
+            sqlProc.stdin.write("SELECT sql FROM sqlite_master WHERE type IS 'table' AND name IS 'warnings';\n");
+            sqlProc.stdout.once('data', tableData => {
+                // The name of the check is contained in property_alias if present, otherwise in property_id
+                const checkIdColumn = tableData.includes("property_alias") ? "property_alias" : "property_id";
 
-                if (expectedRows > 0) {
-                    const query = "SELECT " + fieldsToLoad.join(",") + " FROM warnings;\n";
-                    sqlProc.stdin.write(query);
-                    let output = "";
-                    sqlProc.stdout.on('data', data => {
-                        output += data.toString();
-                        try {
-                            const warnsRaw: string[][] = CsvParser(output);
-                            const warnings = warnsRaw.map(row => parseWarning(row));
-                            if (warnings.length === expectedRows) {
-                                resolve(warnings);  // We are done
-                                sqlProc.kill();
-                            }
-                        } catch (e) { } // CsvParser will throw if we havent recieved all output yet
-                    });
-                } else {
-                    resolve([]);
-                    sqlProc.kill();
-                }
+                sqlProc.stdin.write("SELECT Count(*) FROM warnings;\n");
+                sqlProc.stdout.once('data', data => {
+                    const expectedRows = Number(data.toString());
 
+                    if (expectedRows > 0) {
+                        const query = `SELECT ${fieldsToLoad.join(",")},${checkIdColumn} FROM warnings;\n`;
+                        sqlProc.stdin.write(query);
+                        let output = "";
+                        sqlProc.stdout.on('data', data => {
+                            output += data.toString();
+                            try {
+                                const warnsRaw: string[][] = CsvParser(output);
+                                const warnings = warnsRaw.map(row => parseWarning(row));
+                                if (warnings.length === expectedRows) {
+                                    resolve(warnings);  // We are done
+                                    sqlProc.kill();
+                                }
+                            } catch (e) { } // CsvParser will throw if we havent recieved all output yet
+                        });
+                    } else {
+                        resolve([]);
+                        sqlProc.kill();
+                    }
+
+                }); /* stdout.once() */
             }); /* stdout.once() */
 
             sqlProc.stderr.on('data', data => {
@@ -146,7 +151,7 @@ export namespace CStat {
         const col      = warnRow[fieldsToLoad.indexOf(CStatWarningField.COLUMN)];
         const message  = warnRow[fieldsToLoad.indexOf(CStatWarningField.MSG)];
         const severity = warnRow[fieldsToLoad.indexOf(CStatWarningField.SEVERITY)];
-        const checkId  = warnRow[fieldsToLoad.indexOf(CStatWarningField.CHECKID)];
+        const checkId  = warnRow[warnRow.length - 1];
         return {
             file: file,
             line: Number(line),

--- a/Extension/src/iar/tools/cstat.ts
+++ b/Extension/src/iar/tools/cstat.ts
@@ -112,7 +112,7 @@ export namespace CStat {
         const dbPath = getCStatDBPath(projectPath, configurationName);
         if (Fs.existsSync(dbPath)) { Fs.unlinkSync(dbPath); }
 
-        const iarbuild = spawn(builderPath.toString(), [projectPath.toString(), "-cstat_analyze", configurationName.toString()]);
+        const iarbuild = spawn(builderPath.toString(), [projectPath.toString(), "-cstat_analyze", configurationName.toString(), "-log", "info"]);
         iarbuild.stdout.on("data", data => {
             if (onWrite) {
                 onWrite(data.toString());


### PR DESCRIPTION
Seems i forgot to remove the C-STAT commands after converting them to tasks.
Also adds `-log info` to C-STAT so it looks like it does in EW.
This also fixes a C-STAT freeze for e.g. RL78 when the cstat db doesn't contain the `property_alias` column:
https://github.com/pluyckx/iar-vsc/blob/5ef32dc6905db43c9dfd2dbdf9cbe52628071e55/Extension/src/iar/tools/cstat.ts#L59-L62