### PR TITLE
Use builder instead of ide to validate workbenches

### DIFF
--- a/Extension/src/extension/task/buildtasks.ts
+++ b/Extension/src/extension/task/buildtasks.ts
@@ -8,7 +8,7 @@ import * as Vscode from "vscode";
 import { isArray } from "util";
 import { Settings } from "../settings";
 import { IarExecution } from "./iarexecution";
-import { OsUtils } from "../../utils/utils";
+import { Workbench } from "../../iar/tools/workbench";
 
 export interface BuildTaskDefinition {
     readonly label: string;
@@ -132,7 +132,7 @@ export namespace BuildTasks {
                 label: label,
                 type: "iar",
                 command: command,
-                builder: "${command:iar-settings.workbench}/common/bin/IarBuild" + (OsUtils.detectOsType() == OsUtils.OsType.Windows ? ".exe" : ""),
+                builder: "${command:iar-settings.workbench}/" + Workbench.builderSubPath,
                 project: "${command:iar-settings.project-file}",
                 config: "${command:iar-settings.project-configuration}",
                 problemMatcher: ["$iar-cc", "$iar-linker"]

--- a/Extension/src/extension/task/cstat/cstattaskprovider.ts
+++ b/Extension/src/extension/task/cstat/cstattaskprovider.ts
@@ -5,6 +5,7 @@
 import * as Vscode from "vscode";
 import { OsUtils } from "../../../utils/utils";
 import { CStatTaskExecution } from "./cstattaskexecution";
+import { Workbench } from "../../../iar/tools/workbench";
 
 export namespace CStatTaskProvider {
     let taskProvider: Vscode.Disposable | undefined = undefined;
@@ -92,7 +93,7 @@ class CStatProvider implements Vscode.TaskProvider {
             label: label,
             type: "iar-cstat",
             action: action,
-            builder: "${command:iar-settings.workbench}/common/bin/IarBuild" + (OsUtils.detectOsType() === OsUtils.OsType.Windows ? ".exe" : ""),
+            builder: "${command:iar-settings.workbench}/" + Workbench.builderSubPath,
             project: "${command:iar-settings.project-file}",
             config: "${command:iar-settings.project-configuration}",
         };

--- a/Extension/src/extension/task/opentasks.ts
+++ b/Extension/src/extension/task/opentasks.ts
@@ -8,6 +8,7 @@ import * as Vscode from "vscode";
 import { isArray } from "util";
 import { IarExecution } from "./iarexecution";
 import { OsUtils } from "../../utils/utils";
+import { Workbench } from "../../iar/tools/workbench";
 
 export interface OpenTaskDefinition {
     readonly label: string;
@@ -103,7 +104,7 @@ export namespace OpenTasks {
             label: label,
             type: "iar",
             command: "open",
-            workbench: "${command:iar-settings.workbench}\\\\common\\\\bin\\\\IarIdePm.exe",
+            workbench: "${command:iar-settings.workbench}/" + Workbench.ideSubPath,
             workspace: "${command:iar.selectIarWorkspace}",
             problemMatcher: []
         };

--- a/Extension/src/iar/tools/workbench.ts
+++ b/Extension/src/iar/tools/workbench.ts
@@ -7,10 +7,8 @@
 import * as Fs from "fs";
 import * as Path from "path";
 import { FsUtils } from "../../utils/fs";
-import { ListUtils } from "../../utils/utils";
+import { ListUtils, OsUtils } from "../../utils/utils";
 import { Platform } from "./platform";
-
-const ideSubPath = "common/bin/IarIdePm.exe";
 
 export interface Workbench {
     readonly name: string;
@@ -33,7 +31,7 @@ class IarWorkbench implements Workbench {
      */
     constructor(path: Fs.PathLike) {
         this.path = path;
-        this.idePath = Path.join(this.path.toString(), ideSubPath);
+        this.idePath = Path.join(this.path.toString(), Workbench.ideSubPath);
 
         if (!this.isValid()) {
             throw new Error("Path does not point to a workspace!");
@@ -55,6 +53,9 @@ class IarWorkbench implements Workbench {
 }
 
 export namespace Workbench {
+    export const ideSubPath = "common/bin/IarIdePm.exe";
+    export const builderSubPath = "common/bin/IarBuild" + (OsUtils.OsType.Windows === OsUtils.detectOsType() ? ".exe" : "");
+
     /**
      * Search for valid workbenches. The found workbenches are stored in the
      * Workbench class and are accessible using the static accessor functions.
@@ -116,10 +117,10 @@ export namespace Workbench {
     }
 
     export function isValid(workbenchPath: Fs.PathLike): boolean {
-        const idePath = Path.join(workbenchPath.toString(), ideSubPath);
+        const builderPath = Path.join(workbenchPath.toString(), builderSubPath);
 
         try {
-            const stat = Fs.statSync(idePath);
+            const stat = Fs.statSync(builderPath);
 
             return stat.isFile();
         } catch (e) {


### PR DESCRIPTION
I'm not sure how I missed this before, but the extensions still checks for an `IarIdePm.exe` to check if a folder contains a workbench.
Linux workbenches don't have the ide, so it won't find any workbenches. Instead we should look for an `IarBuilder`.

I also removed some hardcoded ide/build paths.