### PR TITLE
Implement resolveTask to fix two task bugs

### DIFF
--- a/Extension/src/extension/task/buildtasks.ts
+++ b/Extension/src/extension/task/buildtasks.ts
@@ -5,7 +5,6 @@
 'use strict';
 
 import * as Vscode from "vscode";
-import { isArray } from "util";
 import { Settings } from "../settings";
 import { IarExecution } from "./iarexecution";
 import { Workbench } from "../../iar/tools/workbench";
@@ -101,27 +100,6 @@ export namespace BuildTasks {
         }
 
         return task;
-    }
-
-    export function generateFromTasksJson(json: any, dst: Map<string, Vscode.Task>): void {
-        let tasks: any = json["tasks"];
-        let tasksAsArray: Array<any>;
-
-        if ((tasks === undefined) || !isArray(tasks)) {
-            return;
-        } else {
-            tasksAsArray = tasks as Array<any>;
-        }
-
-        tasksAsArray.forEach(taskDefinition => {
-            if (taskDefinition["type"] === "iar") {
-                let task = generateFromDefinition(taskDefinition);
-
-                if (task) {
-                    dst.set(taskDefinition["label"], task);
-                }
-            }
-        });
     }
 
     function generateTask(label: string, command: string): Vscode.Task | undefined {

--- a/Extension/src/extension/task/opentasks.ts
+++ b/Extension/src/extension/task/opentasks.ts
@@ -5,7 +5,6 @@
 'use strict';
 
 import * as Vscode from "vscode";
-import { isArray } from "util";
 import { IarExecution } from "./iarexecution";
 import { OsUtils } from "../../utils/utils";
 import { Workbench } from "../../iar/tools/workbench";
@@ -76,27 +75,6 @@ export namespace OpenTasks {
             task.problemMatchers = definition["problemMatcher"];
         }
         return task;
-    }
-
-    export function generateFromTasksJson(json: any, dst: Map<string, Vscode.Task>): void {
-        let tasks: any = json["tasks"];
-        let tasksAsArray: Array<any>;
-
-        if ((tasks === undefined) || !isArray(tasks)) {
-            return;
-        } else {
-            tasksAsArray = tasks as Array<any>;
-        }
-
-        tasksAsArray.forEach(taskDefinition => {
-            if (taskDefinition["type"] === "iar") {
-                let task = generateFromDefinition(taskDefinition);
-
-                if (task) {
-                    dst.set(taskDefinition["label"], task);
-                }
-            }
-        });
     }
 
     function generateTask(label: string): Vscode.Task | undefined {


### PR DESCRIPTION
Task definitions from the `tasks.json` file are provided to `resolveTask` automatically, so there is no need to read the json file manually. Instead we can use those functions to implement `resolveTask`, which seems to fix #85. Also fixes #78.

Fixes #85 and #78.
